### PR TITLE
Add waterlogging support

### DIFF
--- a/src/main/java/its_meow/betteranimalsplus/common/block/BlockAnimalSkull.java
+++ b/src/main/java/its_meow/betteranimalsplus/common/block/BlockAnimalSkull.java
@@ -5,7 +5,12 @@ import java.util.Map;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
-import net.minecraft.block.*;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockRenderType;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.ContainerBlock;
+import net.minecraft.block.SoundType;
+import net.minecraft.block.IWaterLoggable;
 import net.minecraft.block.material.Material;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.fluid.IFluidState;

--- a/src/main/java/its_meow/betteranimalsplus/common/block/BlockAnimalSkull.java
+++ b/src/main/java/its_meow/betteranimalsplus/common/block/BlockAnimalSkull.java
@@ -5,15 +5,14 @@ import java.util.Map;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockRenderType;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.ContainerBlock;
-import net.minecraft.block.SoundType;
+import net.minecraft.block.*;
 import net.minecraft.block.material.Material;
+import net.minecraft.fluid.Fluids;
+import net.minecraft.fluid.IFluidState;
 import net.minecraft.item.BlockItemUseContext;
 import net.minecraft.state.DirectionProperty;
 import net.minecraft.state.StateContainer;
+import net.minecraft.state.properties.BlockStateProperties;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.Mirror;
@@ -25,7 +24,7 @@ import net.minecraft.world.IBlockReader;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
-public class BlockAnimalSkull extends ContainerBlock {
+public class BlockAnimalSkull extends ContainerBlock implements IWaterLoggable {
 
     public static final DirectionProperty FACING_EXCEPT_DOWN = DirectionProperty.create("facing", Direction.NORTH, Direction.EAST, Direction.SOUTH, Direction.WEST, Direction.UP);
     private static final Map<Direction, VoxelShape> SHAPES = Maps
@@ -38,7 +37,7 @@ public class BlockAnimalSkull extends ContainerBlock {
 
     public BlockAnimalSkull() {
         super(Block.Properties.create(Material.WOOL).sound(SoundType.STONE).hardnessAndResistance(0.8F));
-        this.setDefaultState(this.stateContainer.getBaseState().with(FACING_EXCEPT_DOWN, Direction.NORTH));
+        this.setDefaultState(this.stateContainer.getBaseState().with(FACING_EXCEPT_DOWN, Direction.NORTH).with(BlockStateProperties.WATERLOGGED, false));
     }
 
     @Override
@@ -95,8 +94,13 @@ public class BlockAnimalSkull extends ContainerBlock {
     }
 
     @Override
+    public IFluidState getFluidState(BlockState state) {
+        return state.get(BlockStateProperties.WATERLOGGED) ? Fluids.WATER.getStillFluidState(false) : super.getFluidState(state);
+    }
+
+    @Override
     protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
-        builder.add(FACING_EXCEPT_DOWN);
+        builder.add(FACING_EXCEPT_DOWN, BlockStateProperties.WATERLOGGED);
     }
 
     @Override

--- a/src/main/java/its_meow/betteranimalsplus/common/block/BlockHandOfFate.java
+++ b/src/main/java/its_meow/betteranimalsplus/common/block/BlockHandOfFate.java
@@ -2,7 +2,12 @@ package its_meow.betteranimalsplus.common.block;
 
 import its_meow.betteranimalsplus.common.tileentity.TileEntityHandOfFate;
 import its_meow.betteranimalsplus.init.ModItems;
-import net.minecraft.block.*;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockRenderType;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.HorizontalBlock;
+import net.minecraft.block.IWaterLoggable;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.fluid.Fluids;

--- a/src/main/java/its_meow/betteranimalsplus/common/block/BlockHandOfFate.java
+++ b/src/main/java/its_meow/betteranimalsplus/common/block/BlockHandOfFate.java
@@ -2,17 +2,16 @@ package its_meow.betteranimalsplus.common.block;
 
 import its_meow.betteranimalsplus.common.tileentity.TileEntityHandOfFate;
 import its_meow.betteranimalsplus.init.ModItems;
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockRenderType;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.Blocks;
-import net.minecraft.block.HorizontalBlock;
+import net.minecraft.block.*;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.fluid.Fluids;
+import net.minecraft.fluid.IFluidState;
 import net.minecraft.item.BlockItemUseContext;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.state.StateContainer.Builder;
+import net.minecraft.state.properties.BlockStateProperties;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.Hand;
@@ -27,7 +26,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
-public class BlockHandOfFate extends HorizontalBlock {
+public class BlockHandOfFate extends HorizontalBlock implements IWaterLoggable {
 
     private static VoxelShape SHAPE;
 
@@ -39,7 +38,7 @@ public class BlockHandOfFate extends HorizontalBlock {
     public BlockHandOfFate() {
         super(Properties.create(Material.IRON).hardnessAndResistance(3.0F, 2.0F));
         this.setRegistryName("handoffate");
-        this.setDefaultState(this.getDefaultState().with(HorizontalBlock.HORIZONTAL_FACING, Direction.NORTH));
+        this.setDefaultState(this.getDefaultState().with(HorizontalBlock.HORIZONTAL_FACING, Direction.NORTH).with(BlockStateProperties.WATERLOGGED, false));
     }
 
     @Override
@@ -66,8 +65,13 @@ public class BlockHandOfFate extends HorizontalBlock {
     }
 
     @Override
+    public IFluidState getFluidState(BlockState state) {
+        return state.get(BlockStateProperties.WATERLOGGED) ? Fluids.WATER.getStillFluidState(false) : super.getFluidState(state);
+    }
+
+    @Override
     protected void fillStateContainer(Builder<Block, BlockState> builder) {
-        builder.add(HorizontalBlock.HORIZONTAL_FACING);
+        builder.add(HorizontalBlock.HORIZONTAL_FACING, BlockStateProperties.WATERLOGGED);
     }
 
     @Override


### PR DESCRIPTION
Reason:
This PR adds waterlogging support to `BlockAnimalSkull` and `BlockHandOfFate`.
#101 can be closed once this PR is merged.

Image of changes:
![2019-11-22_16 48 43](https://user-images.githubusercontent.com/5115825/69444758-ed675500-0d48-11ea-93a1-da150d9af6db.png)


<sub>Legal Disclaimer:
ANY PULL REQUEST SUBMITTED TO "The Project" (github.com/itsmeow/betteranimalsplus) AND MERGED INTO A RELEASED VERSION OF THE MODIFICATION (content released via CurseForge.com) BECOMES PROPERTY OF "THE OWNER" (its_meow and partner cybercat5555). ALL RIGHTS TO THE SUBMITTED CONTENT IS TRANSFERRED TO THE OWNER. Credit may or may not be given at The Owner's choice.</sub>
