### PR TITLE
Add tag support to taming item config and fix taming item config.

### DIFF
--- a/src/main/java/its_meow/betteranimalsplus/common/entity/EntityTameableBetterAnimalsPlus.java
+++ b/src/main/java/its_meow/betteranimalsplus/common/entity/EntityTameableBetterAnimalsPlus.java
@@ -19,7 +19,7 @@ public abstract class EntityTameableBetterAnimalsPlus extends TameableEntity {
         String id = item.getRegistryName().toString();
         for(String itemsId : items) {
             if (itemsId.startsWith("#")) {
-                if (item.getTags().contains(new ResourceLocation(itemsId.split("#")[1]))) {
+                if (item.getTags().contains(new ResourceLocation(itemsId.substring(1, itemsId.length)))) {
                     return true;
                 }
             } else if(id.equals(itemsId)) {

--- a/src/main/java/its_meow/betteranimalsplus/common/entity/EntityTameableBetterAnimalsPlus.java
+++ b/src/main/java/its_meow/betteranimalsplus/common/entity/EntityTameableBetterAnimalsPlus.java
@@ -4,6 +4,7 @@ import its_meow.betteranimalsplus.util.EntityTypeContainerTameable;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.passive.TameableEntity;
 import net.minecraft.item.Item;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 
 public abstract class EntityTameableBetterAnimalsPlus extends TameableEntity {
@@ -17,7 +18,11 @@ public abstract class EntityTameableBetterAnimalsPlus extends TameableEntity {
         String[] items = container.getTameItems();
         String id = item.getRegistryName().toString();
         for(String itemsId : items) {
-            if(id.equals(itemsId)) {
+            if (itemsId.startsWith("#")) {
+                if (item.getTags().contains(new ResourceLocation(itemsId.split("#")[1]))) {
+                    return true;
+                }
+            } else if(id.equals(itemsId)) {
                 return true;
             }
         }

--- a/src/main/java/its_meow/betteranimalsplus/util/EntityTypeContainerTameable.java
+++ b/src/main/java/its_meow/betteranimalsplus/util/EntityTypeContainerTameable.java
@@ -22,7 +22,7 @@ import net.minecraftforge.common.ForgeConfigSpec.ConfigValue;
 public class EntityTypeContainerTameable<T extends LivingEntity> extends EntityTypeContainer<T> {
 
     protected String[] tameItemsStore;
-    protected ConfigValue<List<String>> tameItems;
+    protected ConfigValue<List<? extends String>> tameItems;
     protected String[] defaultTameItems;
 
     public EntityTypeContainerTameable(Class<T> EntityClass, Function<World, T> func,
@@ -61,7 +61,7 @@ public class EntityTypeContainerTameable<T extends LivingEntity> extends EntityT
     @Override
     public void customConfigurationInit(Builder builder) {
         super.customConfigurationInit(builder);
-        this.tameItems = builder.comment("List of acceptable item IDs to use for taming").worldRestart().define("tameItems", Arrays.asList(defaultTameItems), (Predicate<Object>) input -> input instanceof String);
+        this.tameItems = builder.comment("List of acceptable item IDs to use for taming. Accepts tags by prefixing them with '#'.").worldRestart().defineList("tameItems", Arrays.asList(defaultTameItems), (Predicate<Object>) input -> input instanceof String);
     }
 
 }


### PR DESCRIPTION
Reason:
This PR adds tag support to the taming item config.
It also fixes the taming item config, letting it be modified without forge nuking it on world load.
It solves #110 for 1.14, but not 1.12.


<sub>Legal Disclaimer:
ANY PULL REQUEST SUBMITTED TO "The Project" (github.com/itsmeow/betteranimalsplus) AND MERGED INTO A RELEASED VERSION OF THE MODIFICATION (content released via CurseForge.com) BECOMES PROPERTY OF "THE OWNER" (its_meow and partner cybercat5555). ALL RIGHTS TO THE SUBMITTED CONTENT IS TRANSFERRED TO THE OWNER. Credit may or may not be given at The Owner's choice.</sub>
