### PR TITLE
Make Portable Jukeboxes from standalone mod do crabrave

### DIFF
--- a/src/main/java/its_meow/betteranimalsplus/common/CommonEventHandler.java
+++ b/src/main/java/its_meow/betteranimalsplus/common/CommonEventHandler.java
@@ -57,9 +57,6 @@ public class CommonEventHandler {
         NO_ATTACKED_DROPS.add(e -> e instanceof EntityOctopus && ((EntityOctopus) e).friend == null);
     }
 
-    @ObjectHolder("essentialfeatures:portable_jukebox")
-    public static Item PORTABLE_JUKEBOX;
-
     @SubscribeEvent
     public static void onDeathOfEntity(LivingDeathEvent e) {
         if(e.getSource().getImmediateSource() instanceof EntityBoar) {
@@ -140,7 +137,8 @@ public class CommonEventHandler {
 
     @SubscribeEvent
     public static void onItemUsed(PlayerInteractEvent.RightClickItem event) {
-        if(PORTABLE_JUKEBOX != null && event.getItemStack().getItem() == PORTABLE_JUKEBOX) {
+        ResourceLocation itemRegistryName = event.getItemStack().getItem().getRegistryName();
+        if(itemRegistryName != null && itemRegistryName.getPath().equals("portable_jukebox")) {
             if(event.getItemStack().getChildTag("Disc") != null) {
                 Item item = ItemStack.read(event.getItemStack().getChildTag("Disc")).getItem();
                 if(item == ModItems.RECORD_CRAB_RAVE.get()) {


### PR DESCRIPTION
Reason:

Fixes the Portable Jukeboxes from the standalone Portable Jukebox mod not triggering crabrave like how the Essential Features ones do.

This was written entirely in the GitHub web interface, so it's untested.

<sub>Legal Disclaimer:
ANY PULL REQUEST SUBMITTED TO "The Project" (github.com/itsmeow/betteranimalsplus) AND MERGED INTO A RELEASED VERSION OF THE MODIFICATION (content released via CurseForge.com) BECOMES PROPERTY OF "THE OWNER" (its_meow and partner cybercat5555). ALL RIGHTS TO THE SUBMITTED CONTENT IS TRANSFERRED TO THE OWNER. Credit may or may not be given at The Owner's choice.</sub>
