### PR TITLE
(1.18.x) Optimise and cleanup

### DIFF
--- a/common/src/main/java/dev/itsmeow/betteranimalsplus/common/blockentity/BlockEntityTrillium.java
+++ b/common/src/main/java/dev/itsmeow/betteranimalsplus/common/blockentity/BlockEntityTrillium.java
@@ -73,17 +73,11 @@ public class BlockEntityTrillium extends BlockEntity {
         BlockState state = this.level.getBlockState(this.worldPosition);
         if (state.getBlock() == ModBlocks.TRILLIUM.get()) {
             Direction facing = state.getValue(HorizontalDirectionalBlock.FACING).getOpposite();
-            if (facing == Direction.NORTH) {
-                return 0F;
-            }
-            if (facing == Direction.EAST) {
-                return 90F;
-            }
-            if (facing == Direction.SOUTH) {
-                return 180F;
-            }
-            if (facing == Direction.WEST) {
-                return 270F;
+            switch (facing) {
+                case NORTH: return 0F;
+                case EAST: return 90F;
+                case SOUTH: return 180F;
+                case WEST: return 270F;
             }
         }
         return 0F;

--- a/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityBadger.java
+++ b/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityBadger.java
@@ -35,6 +35,11 @@ import java.util.Set;
 
 public class EntityBadger extends EntityAnimalWithSelectiveTypes implements Enemy {
 
+	private static final String[] SAVANNA_TYPES = new String[] { "honey" };
+	private static final String[] FOREST_TYPES = new String[] { "european" };
+	private static final String[] CONIFEROUS_TYPES = new String[] { "american" };
+	private static final String[] ALL_TYPES = new String[] { "american", "european", "honey" };
+
     public EntityBadger(EntityType<? extends EntityBadger> entityType, Level worldIn) {
         super(entityType, worldIn);
     }
@@ -121,8 +126,8 @@ public class EntityBadger extends EntityAnimalWithSelectiveTypes implements Enem
 		@Override
 		public void tick() {
 			tick++;
-			LivingEntity t = badger.getTarget();
 			if(tick % 15 == 0) { // Throw dirt every second (20 ticks)
+				LivingEntity t = badger.getTarget();
 				EntityBadgerDirt proj = new EntityBadgerDirt(ModEntities.PROJECTILE_BADGER_DIRT.get(), badger.level, badger, stateId);
 				proj.moveTo(badger.getX(), badger.getY() + 1, badger.getZ(), 0, 0);
 				double d0 = t.getY() + t.getEyeHeight() - 1.100000023841858D;
@@ -149,13 +154,13 @@ public class EntityBadger extends EntityAnimalWithSelectiveTypes implements Enem
     @Override
     public String[] getTypesFor(ResourceKey<Biome> biomeKey, Biome biome, Set<BiomeTypes.Type> types, MobSpawnType reason) {
         if(types.contains(BiomeTypes.SAVANNA)) {
-            return new String[] { "honey" };
+            return SAVANNA_TYPES;
         } else if(types.contains(BiomeTypes.FOREST) && !types.contains(BiomeTypes.CONIFEROUS)) {
-            return new String[] { "european" };
+            return FOREST_TYPES;
         } else if(types.contains(BiomeTypes.CONIFEROUS)) {
-            return new String[] { "american" };
+            return CONIFEROUS_TYPES;
         } else {
-            return new String[] { "american", "european", "honey" };
+            return ALL_TYPES;
         }
     }
 

--- a/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityBadger.java
+++ b/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityBadger.java
@@ -152,9 +152,7 @@ public class EntityBadger extends EntityAnimalWithSelectiveTypes implements Enem
             return new String[] { "honey" };
         } else if(types.contains(BiomeTypes.FOREST) && !types.contains(BiomeTypes.CONIFEROUS)) {
             return new String[] { "european" };
-        } else if(types.contains(BiomeTypes.CONIFEROUS) && !types.contains(BiomeTypes.SNOWY)) {
-            return new String[] { "american" };
-        } else if(types.contains(BiomeTypes.CONIFEROUS) && types.contains(BiomeTypes.SNOWY)) {
+        } else if(types.contains(BiomeTypes.CONIFEROUS)) {
             return new String[] { "american" };
         } else {
             return new String[] { "american", "european", "honey" };

--- a/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityBoar.java
+++ b/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityBoar.java
@@ -47,6 +47,9 @@ import java.util.Set;
 
 public class EntityBoar extends EntityAnimalWithSelectiveTypes implements Enemy, IDropHead<EntityAnimalWithTypes> {
 
+    private static final String[] SNOWY_CONIFEROUS_TYPES = new String[] { "dark_brown", "gray" };
+    private static final String[] ALL_BOAR_TYPES = new String[] { "dark_brown", "light_brown", "gray" };
+
     public EntityBoar(EntityType<? extends EntityBoar> entityType, Level worldIn) {
         super(entityType, worldIn);
         this.setPathfindingMalus(BlockPathTypes.DANGER_OTHER, 0.0F);
@@ -227,11 +230,11 @@ public class EntityBoar extends EntityAnimalWithSelectiveTypes implements Enemy,
     @Override
     public String[] getTypesFor(ResourceKey<Biome> biomeKey, Biome biome, Set<BiomeTypes.Type> types, MobSpawnType reason) {
        if(types.contains(BiomeTypes.CONIFEROUS) && types.contains(BiomeTypes.SNOWY)) {
-            return new String[] { "dark_brown", "gray" };
+            return SNOWY_CONIFEROUS_TYPES;
         } else if(types.contains(BiomeTypes.SNOWY) && !types.contains(BiomeTypes.CONIFEROUS) && !types.contains(BiomeTypes.FOREST)) {
             return new String[] { "gray" };
         } else {
-            return new String[] { "dark_brown", "light_brown", "gray" };
+            return ALL_BOAR_TYPES;
         }
     }
 

--- a/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityCrab.java
+++ b/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityCrab.java
@@ -87,7 +87,7 @@ public class EntityCrab extends EntityCrabLikeBase {
         if(!level.isClientSide()) {
             if (this.raveTicks > 0) {
                 this.raveTicks--;
-            } else if (this.raveTicks <= 0 && this.getIsCrabRave() > 0) {
+            } else if (this.getIsCrabRave() > 0) {
                 this.unCrabRave();
             }
         }

--- a/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityFeralWolf.java
+++ b/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityFeralWolf.java
@@ -67,6 +67,9 @@ public class EntityFeralWolf extends EntityTameableWithSelectiveTypes implements
     public static final double TAMED_HEALTH = 30D;
     public static final double UNTAMED_HEALTH = 10D;
     protected static final EntityDataAccessor<Float> DATA_HEALTH_ID = SynchedEntityData.defineId(EntityFeralWolf.class, EntityDataSerializers.FLOAT);
+    private static final String[] SNOWY_CONIFEROUS_TYPES = new String[] {"snowy", "timber"};
+    private static final String[] CONIFEROUS_FOREST_TYPES = new String[] {"brown", "red", "timber", "black"};
+    private static final String[] ALL_TYPES = new String[] {"black", "snowy", "timber", "arctic", "brown", "red"};
 
     private int hunger;
 
@@ -329,16 +332,18 @@ public class EntityFeralWolf extends EntityTameableWithSelectiveTypes implements
     public String[] getTypesFor(ResourceKey<Biome> biomeKey, Biome biome, Set<BiomeTypes.Type> types, MobSpawnType reason) {
         if(types.contains(BiomeTypes.FOREST) && !types.contains(BiomeTypes.CONIFEROUS)) {
             return new String[] {"timber", "red"};
-        } else if(types.contains(BiomeTypes.CONIFEROUS) && !types.contains(BiomeTypes.SNOWY)) {
-            return new String[] {"black", "timber", "red"};
-        } else if(types.contains(BiomeTypes.CONIFEROUS) && types.contains(BiomeTypes.SNOWY)) {
-            return new String[] {"snowy", "timber"};
+        } else if(types.contains(BiomeTypes.CONIFEROUS)) {
+            if(types.contains(BiomeTypes.SNOWY)) {
+                return SNOWY_CONIFEROUS_TYPES;
+            } else {
+                return new String[] {"black", "timber", "red"};
+            }
         } else if(types.contains(BiomeTypes.SNOWY) && !types.contains(BiomeTypes.FOREST)) {
             return new String[] {"snowy", "arctic"};
         } else if(types.contains(BiomeTypes.FOREST) && types.contains(BiomeTypes.CONIFEROUS) && !types.contains(BiomeTypes.SNOWY)) {
-            return new String[] {"brown", "red", "timber", "black"};
+            return CONIFEROUS_FOREST_TYPES;
         } else {
-            return new String[] {"black", "snowy", "timber", "arctic", "brown", "red"};
+            return ALL_TYPES;
         }
     }
 

--- a/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityGoose.java
+++ b/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityGoose.java
@@ -62,6 +62,9 @@ public class EntityGoose extends EntityAnimalWithTypes {
     public int timeUntilNextEgg;
     public static final String PICKUP_BLOCK_LIST_KEY = "pickup_blacklist";
     private static final Set<Item> BREEDING_ITEMS = Sets.newHashSet(Items.PUMPKIN_SEEDS, Items.WHEAT_SEEDS, Items.BEETROOT_SEEDS, Items.MELON_SEEDS, Items.SEAGRASS);
+    private static final String[] ONE_STR = new String[] { "1" };
+    private static final String[] TWO_THREE_STR = new String[] { "2", "3" };
+    private static final String[] ONE_TWO_THREE_STR = new String[] { "1", "2", "3" };
 
     public EntityGoose(EntityType<? extends EntityGoose> entityType, Level worldIn) {
         super(entityType, worldIn);
@@ -343,13 +346,13 @@ public class EntityGoose extends EntityAnimalWithTypes {
         case NATURAL:
         case CHUNK_GENERATION:
         case STRUCTURE:
-            types = new String[] {"2","3"};
+            types = TWO_THREE_STR; // ["2", "3"]
             break;
         case BREEDING:
-            types = new String[] {"1"};
+            types = ONE_STR; // ["1"]
             break;
         default:
-            types = new String[] {"1","2","3"};
+            types = ONE_TWO_THREE_STR; // ["1", "2", "3"]
             break;
         }
         livingdata = EntityUtil.childChance(this, reason, livingdata, 0.25F);

--- a/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityGoose.java
+++ b/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityGoose.java
@@ -161,30 +161,32 @@ public class EntityGoose extends EntityAnimalWithTypes {
     @Override
     public void aiStep() {
         super.aiStep();
-        if(!this.level.isClientSide && this.isAlive() && this.isEffectiveAi()) {
-            ItemStack itemstack = this.getItemBySlot(EquipmentSlot.MAINHAND);
-            if(itemstack.getItem().isEdible() && this.getTarget() == null) {
-                ++this.eatTicks;
-                if(this.eatTicks > 200) {
-                    if(itemstack.getItem() == Items.BREAD) {
-                        this.addEffect(new MobEffectInstance(MobEffects.POISON, 900));
-                    }
-                    ItemStack itemstack1 = itemstack.finishUsingItem(this.level, this);
+        if(!this.level.isClientSide) {
+            if(this.isAlive() && this.isEffectiveAi()) {
+                ItemStack itemstack = this.getItemBySlot(EquipmentSlot.MAINHAND);
+                if(itemstack.getItem().isEdible() && this.getTarget() == null) {
+                    ++this.eatTicks;
+                    if(this.eatTicks > 200) {
+                        if(itemstack.getItem() == Items.BREAD) {
+                            this.addEffect(new MobEffectInstance(MobEffects.POISON, 900));
+                        }
+                        ItemStack itemstack1 = itemstack.finishUsingItem(this.level, this);
 
-                    if(!itemstack1.isEmpty()) {
-                        this.setItemSlot(EquipmentSlot.MAINHAND, itemstack1);
+                        if(!itemstack1.isEmpty()) {
+                            this.setItemSlot(EquipmentSlot.MAINHAND, itemstack1);
+                        }
+                        this.eatTicks = 0;
+                    } else if(this.eatTicks > 160 && this.random.nextFloat() < 0.1F) {
+                        this.playSound(this.getEatingSound(itemstack), 1.0F, 1.0F);
+                        this.level.broadcastEntityEvent(this, (byte) 45); // calls handleStatusUpdate((byte) 45);
                     }
-                    this.eatTicks = 0;
-                } else if(this.eatTicks > 160 && this.random.nextFloat() < 0.1F) {
-                    this.playSound(this.getEatingSound(itemstack), 1.0F, 1.0F);
-                    this.level.broadcastEntityEvent(this, (byte) 45); // calls handleStatusUpdate((byte) 45);
                 }
             }
-        }
-        if(!this.level.isClientSide && !this.isBaby() && ModEventBus.LayEggTickEvent.emit(this) && --this.timeUntilNextEgg <= 0) {
-            this.playSound(SoundEvents.CHICKEN_EGG, 1.0F, (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 1.0F);
-            this.spawnAtLocation(this.getRandom().nextInt(128) == 0 ? ModItems.GOLDEN_GOOSE_EGG.get() : ModItems.GOOSE_EGG.get(), 1);
-            this.timeUntilNextEgg = this.random.nextInt(6000) + 6000;
+            if(!this.isBaby() && ModEventBus.LayEggTickEvent.emit(this) && --this.timeUntilNextEgg <= 0) {
+                this.playSound(SoundEvents.CHICKEN_EGG, 1.0F, (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 1.0F);
+                this.spawnAtLocation(this.getRandom().nextInt(128) == 0 ? ModItems.GOLDEN_GOOSE_EGG.get() : ModItems.GOOSE_EGG.get(), 1);
+                this.timeUntilNextEgg = this.random.nextInt(6000) + 6000;
+            }
         }
     }
 
@@ -339,11 +341,7 @@ public class EntityGoose extends EntityAnimalWithTypes {
         String[] types;
         switch (reason) {
         case NATURAL:
-            types = new String[] {"2","3"};
-            break;
         case CHUNK_GENERATION:
-            types = new String[] {"2","3"};
-            break;
         case STRUCTURE:
             types = new String[] {"2","3"};
             break;

--- a/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityLammergeier.java
+++ b/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityLammergeier.java
@@ -362,8 +362,8 @@ public class EntityLammergeier extends EntityTameableFlyingWithTypes implements 
 
             if(entitylivingbase.distanceToSqr(this.attacker) < 4096.0D) // If the distance is less than 4096 square blocks rotate towards them
             {
-                double d1 = entitylivingbase.getX() - this.attacker.getX();
-                double d2 = entitylivingbase.getZ() - this.attacker.getZ();
+                double d1 = targetX - this.attacker.getX();
+                double d2 = targetZ - this.attacker.getZ();
                 this.attacker.setYRot(-((float) Mth.atan2(d1, d2)) * (180F / (float) Math.PI));
                 this.attacker.yBodyRot = this.attacker.getYRot();
             }

--- a/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityMoose.java
+++ b/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityMoose.java
@@ -67,8 +67,8 @@ public class EntityMoose extends EntityAnimalEatsGrassWithTypes implements IDrop
         AABB axisalignedbb = this.getBoundingBox();
         BlockPos blockpos = new BlockPos(axisalignedbb.minX + 0.001D, axisalignedbb.minY + 0.001D, axisalignedbb.minZ + 0.001D);
         BlockPos blockpos1 = new BlockPos(axisalignedbb.maxX - 0.001D, axisalignedbb.maxY - 0.001D, axisalignedbb.maxZ - 0.001D);
-        BlockPos.MutableBlockPos blockpos$mutable = new BlockPos.MutableBlockPos();
         if(this.level.hasChunksAt(blockpos, blockpos1)) {
+            BlockPos.MutableBlockPos blockpos$mutable = new BlockPos.MutableBlockPos();
             for(int i = blockpos.getX(); i <= blockpos1.getX(); ++i) {
                 for(int j = blockpos.getY(); j <= blockpos1.getY(); ++j) {
                     for(int k = blockpos.getZ(); k <= blockpos1.getZ(); ++k) {

--- a/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityReindeer.java
+++ b/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityReindeer.java
@@ -273,9 +273,9 @@ public class EntityReindeer extends Animal implements PlayerRideableJumping, IVa
             }
             BlockPos pos = new BlockPos(this.getX(), this.getY() - 0.2D - this.yRotO, this.getZ());
             BlockState iblockstate = this.level.getBlockState(pos);
-            Block block = iblockstate.getBlock();
 
             if (iblockstate.getMaterial() != Material.AIR && !this.isSilent()) {
+                Block block = iblockstate.getBlock();
                 SoundType soundtype = block.getSoundType(block.defaultBlockState());
                 this.level.playSound(null, this.getX(), this.getY(), this.getZ(), soundtype.getStepSound(),
                         this.getSoundSource(), soundtype.getVolume() * 0.5F, soundtype.getPitch() * 0.75F);

--- a/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityShark.java
+++ b/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityShark.java
@@ -100,16 +100,21 @@ public class EntityShark extends EntitySharkBase {
 
     public boolean shouldAttackForHealth(float health) {
         switch(this.getVariantNameOrEmpty()) {
-        case "blue": return health <= 8F;
-        case "bull": return health <= 13F;
-        case "tiger": return health <= 10F;
-        case "whitetip": return health <= 16F;
-        case "greenland": return health <= 8F;
-        case "hammerhead": return health <= 8F;
-        case "goblin": return health <= 8F;
-        case "mako": return health <= 13F;
-        case "great_white": return health <= 13F;
-        default: return false;
+            case "blue":
+            case "greenland":
+            case "hammerhead":
+            case "goblin":
+                return health <= 8F;
+            case "bull":
+            case "mako":
+            case "great_white":
+                return health <= 13F;
+            case "tiger":
+                return health <= 10F;
+            case "whitetip":
+                return health <= 16F;
+            default:
+                return false;
         }
     }
 
@@ -219,7 +224,7 @@ public class EntityShark extends EntitySharkBase {
             }
         }
         Optional<IVariant> variant = this.getContainer().getVariantForName(varStr);
-        if(!variant.isPresent() || !varStr.equals(variant.get().getName())) {
+        if(variant.isEmpty() || !varStr.equals(variant.get().getName())) {
             throw new RuntimeException("Received invalid variant \"" + varStr + "\" from selective type on entity " + this.getContainer().getEntityName());
         }
         return variant.get();

--- a/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntitySongbird.java
+++ b/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntitySongbird.java
@@ -51,6 +51,9 @@ public class EntitySongbird extends EntityAnimalWithSelectiveTypes implements Fl
     protected static final Set<Item> SEEDS = Sets.newHashSet(Items.WHEAT_SEEDS, Items.MELON_SEEDS, Items.PUMPKIN_SEEDS, Items.BEETROOT_SEEDS);
     public float flapSpeed = 1.0F;
     private float nextFlap = 1.0F;
+    private static final String[] CONIFEROUS_TYPES = new String[] { "1", "small_5", "small_6" };
+    private static final String[] SNOWY_CONIFEROUS_TYPES = new String[] { "3", "4", "small_1" };
+    private static final String[] ALL_TYPES = new String[] { "1", "2", "3", "4", "small_1", "small_2", "small_3", "small_4", "small_5", "small_6" };
 
     public EntitySongbird(EntityType<? extends EntitySongbird> entityType, Level worldIn) {
         super(entityType, worldIn);
@@ -179,12 +182,14 @@ public class EntitySongbird extends EntityAnimalWithSelectiveTypes implements Fl
     public String[] getTypesFor(ResourceKey<Biome> biomeKey, Biome biome, Set<BiomeTypes.Type> types, MobSpawnType reason) {
         if(types.contains(BiomeTypes.FOREST) && !types.contains(BiomeTypes.CONIFEROUS)) {
             return new String[] { "2", "small_2", "small_3", "small_4" };
-        } else if(types.contains(BiomeTypes.CONIFEROUS) && !types.contains(BiomeTypes.SNOWY)) {
-            return new String[] { "1", "small_5", "small_6" };
-        } else if(types.contains(BiomeTypes.CONIFEROUS) && types.contains(BiomeTypes.SNOWY)) {
-            return new String[] { "3", "4", "small_1" };
+        } else if(types.contains(BiomeTypes.CONIFEROUS)) {
+            if (types.contains(BiomeTypes.SNOWY)) {
+                return SNOWY_CONIFEROUS_TYPES;
+            } else {
+                return CONIFEROUS_TYPES;
+            }
         } else {
-            return new String[] { "1", "2", "3", "4", "small_1", "small_2", "small_3", "small_4", "small_5", "small_6" };
+            return ALL_TYPES;
         }
     }
 

--- a/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntitySquirrel.java
+++ b/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntitySquirrel.java
@@ -37,6 +37,7 @@ import java.util.Set;
 public class EntitySquirrel extends EntityAnimalWithSelectiveTypes {
 
     protected static final EntityDataAccessor<Byte> CLIMBING = SynchedEntityData.defineId(EntitySquirrel.class, EntityDataSerializers.BYTE);
+    private static final String[] ALL_TYPES = new String[] { "gray", "red", "albino" };
 
     private int climbTimeWithoutLog = 0;
 
@@ -163,7 +164,7 @@ public class EntitySquirrel extends EntityAnimalWithSelectiveTypes {
         } else if(types.contains(BiomeTypes.CONIFEROUS) && !types.contains(BiomeTypes.SNOWY)) {
             return new String[] { "red" };
         } else {
-            return new String[] { "gray", "red", "albino" };
+            return ALL_TYPES;
         }
     }
 

--- a/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityTarantula.java
+++ b/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityTarantula.java
@@ -29,6 +29,10 @@ import java.util.Set;
 
 public class EntityTarantula extends Spider implements RangedAttackMob, ISelectiveVariantTypes<EntityTarantula> {
 
+    private static final String[] JUNGLE_TYPES = new String[] { "jungle_1", "jungle_2", "jungle_3" };
+    private static final String[] SANDY_TYPES = new String[] { "desert_1", "desert_2", "desert_3" };
+    private static final String[] ALL_TYPES = new String[] { "desert_1", "desert_2", "desert_3", "jungle_1", "jungle_2", "jungle_3" };
+
     public EntityTarantula(EntityType<? extends EntityTarantula> entityType, Level worldIn) {
         super(entityType, worldIn);
     }
@@ -105,11 +109,11 @@ public class EntityTarantula extends Spider implements RangedAttackMob, ISelecti
     @Override
     public String[] getTypesFor(ResourceKey<Biome> biomeKey, Biome biome, Set<BiomeTypes.Type> types, MobSpawnType reason) {
         if(types.contains(BiomeTypes.JUNGLE)) {
-            return new String[] { "jungle_1", "jungle_2", "jungle_3" };
+            return JUNGLE_TYPES;
         } else if(types.contains(BiomeTypes.SANDY)) {
-            return new String[] { "desert_1", "desert_2", "desert_3" };
+            return SANDY_TYPES;
         } else {
-            return new String[] { "desert_1", "desert_2", "desert_3", "jungle_1", "jungle_2", "jungle_3" };
+            return ALL_TYPES;
         }
     }
 }

--- a/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityTurkey.java
+++ b/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityTurkey.java
@@ -155,16 +155,17 @@ public class EntityTurkey extends EntityAnimalWithTypes {
             }
         }
 
-        if(!this.level.isClientSide && this.setPeckTime(this.getPeckTime() - 1) <= 0) {
-            this.setPeckTime(this.getNewPeck());
-        }
+        if(!this.level.isClientSide) {
+            if(this.setPeckTime(this.getPeckTime() - 1) <= 0) {
+                this.setPeckTime(this.getNewPeck());
+            }
 
-        if(!this.level.isClientSide && !this.isBaby() && ModEventBus.LayEggTickEvent.emit(this) && --this.timeUntilNextEgg <= 0) {
-            this.playSound(SoundEvents.CHICKEN_EGG, 1.0F, (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 1.0F);
-            this.spawnAtLocation(ModItems.TURKEY_EGG.get(), 1);
-            this.timeUntilNextEgg = this.random.nextInt(6000) + 6000;
-        }
-        if(!level.isClientSide) {
+            if(!this.isBaby() && ModEventBus.LayEggTickEvent.emit(this) && --this.timeUntilNextEgg <= 0) {
+                this.playSound(SoundEvents.CHICKEN_EGG, 1.0F, (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 1.0F);
+                this.spawnAtLocation(ModItems.TURKEY_EGG.get(), 1);
+                this.timeUntilNextEgg = this.random.nextInt(6000) + 6000;
+            }
+
             if(this.isInLove() && !this.isTailUp()) {
                 this.setTailUp(true);
             }

--- a/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityWhale.java
+++ b/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityWhale.java
@@ -80,13 +80,17 @@ public class EntityWhale extends EntityWaterMobPathingWithTypesAirBreathing impl
                 if(entityIn instanceof Player) {
                     Player player = (Player) entityIn;
                     int ticks = 0;
-                    if (this.level.getDifficulty() == Difficulty.EASY) {
-                        ticks = 50;
-                    } else if (this.level.getDifficulty() == Difficulty.NORMAL) {
-                        ticks = 100;
-                    } else if (this.level.getDifficulty() == Difficulty.HARD) {
-                        ticks = 140;
-                    }
+                    switch (this.level.getDifficulty()) {
+                        case EASY:
+                            ticks = 50;
+                            break;
+                        case NORMAL:
+                            ticks = 100;
+                            break;
+                        case HARD:
+                            ticks = 140;
+                            break;
+                    };
                     player.addEffect(new MobEffectInstance(MobEffects.MOVEMENT_SLOWDOWN, ticks, 1, false, false));
                     player.addEffect(new MobEffectInstance(MobEffects.CONFUSION, ticks + 40, 1, false, false));
                 }

--- a/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/ai/EfficientMoveTowardsTargetGoal.java
+++ b/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/ai/EfficientMoveTowardsTargetGoal.java
@@ -87,9 +87,9 @@ public class EfficientMoveTowardsTargetGoal extends Goal {
     public void tick() {
         LivingEntity livingentity = this.attacker.getTarget();
         this.attacker.getLookControl().setLookAt(livingentity, 30.0F, 30.0F);
-        double d0 = this.attacker.distanceToSqr(livingentity.getX(), livingentity.getY(), livingentity.getZ());
         --this.delayCounter;
         if ((this.longMemory || this.attacker.getSensing().hasLineOfSight(livingentity)) && this.delayCounter <= 0 && (this.targetX == 0.0D && this.targetY == 0.0D && this.targetZ == 0.0D || livingentity.distanceToSqr(this.targetX, this.targetY, this.targetZ) >= 1.0D || this.attacker.getRandom().nextFloat() < 0.05F)) {
+            double d0 = this.attacker.distanceToSqr(livingentity.getX(), livingentity.getY(), livingentity.getZ());
             this.targetX = livingentity.getX();
             this.targetY = livingentity.getY();
             this.targetZ = livingentity.getZ();

--- a/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/projectile/EntityBadgerDirt.java
+++ b/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/projectile/EntityBadgerDirt.java
@@ -51,8 +51,7 @@ public class EntityBadgerDirt extends ThrowableProjectile {
     protected void onHit(HitResult result) {
         if(result instanceof EntityHitResult) {
             EntityHitResult rayR = (EntityHitResult) result;
-            int i = 2;
-            rayR.getEntity().hurt(DamageSource.thrown(this, this.getOwner()), i);
+            rayR.getEntity().hurt(DamageSource.thrown(this, this.getOwner()), 2);
             if(!this.level.isClientSide && Math.random() >= 0.5) {
                 if(rayR.getEntity() instanceof Player) {
                     Player player = (Player) rayR.getEntity();

--- a/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/projectile/EntityBadgerDirt.java
+++ b/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/projectile/EntityBadgerDirt.java
@@ -53,16 +53,20 @@ public class EntityBadgerDirt extends ThrowableProjectile {
             EntityHitResult rayR = (EntityHitResult) result;
             int i = 2;
             rayR.getEntity().hurt(DamageSource.thrown(this, this.getOwner()), i);
-            if(Math.random() >= 0.5 && !this.level.isClientSide) {
+            if(!this.level.isClientSide && Math.random() >= 0.5) {
                 if(rayR.getEntity() instanceof Player) {
                     Player player = (Player) rayR.getEntity();
                     int blindnessTicks = 0;
-                    if(player.getCommandSenderWorld().getDifficulty() == Difficulty.EASY) {
-                        blindnessTicks = 10;
-                    } else if(player.getCommandSenderWorld().getDifficulty() == Difficulty.NORMAL) {
-                        blindnessTicks = 20;
-                    } else if(player.getCommandSenderWorld().getDifficulty() == Difficulty.HARD) {
-                        blindnessTicks = 35;
+                    switch (player.getCommandSenderWorld().getDifficulty()) {
+                        case EASY:
+                            blindnessTicks = 10;
+                            break;
+                        case NORMAL:
+                            blindnessTicks = 20;
+                            break;
+                        case HARD:
+                            blindnessTicks = 35;
+                            break;
                     }
                     player.addEffect(new MobEffectInstance(MobEffects.BLINDNESS, blindnessTicks, 2, false, false));
                 }

--- a/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/projectile/EntityTarantulaHair.java
+++ b/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/projectile/EntityTarantulaHair.java
@@ -31,8 +31,7 @@ public class EntityTarantulaHair extends ThrowableProjectile {
     protected void onHit(HitResult result) {
         if(result instanceof EntityHitResult) {
             EntityHitResult rayR = (EntityHitResult) result;
-            int i = 8;
-            rayR.getEntity().hurt(DamageSource.thrown(this, this.getOwner()), i);
+            rayR.getEntity().hurt(DamageSource.thrown(this, this.getOwner()), 8);
             if(!this.level.isClientSide) {
                 if(rayR.getEntity() instanceof Player) {
                     Player player = (Player) rayR.getEntity();

--- a/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/projectile/EntityTarantulaHair.java
+++ b/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/projectile/EntityTarantulaHair.java
@@ -37,12 +37,16 @@ public class EntityTarantulaHair extends ThrowableProjectile {
                 if(rayR.getEntity() instanceof Player) {
                     Player player = (Player) rayR.getEntity();
                     int blindnessTicks = 0;
-                    if(player.getCommandSenderWorld().getDifficulty() == Difficulty.EASY) {
-                        blindnessTicks = 40;
-                    } else if(player.getCommandSenderWorld().getDifficulty() == Difficulty.NORMAL) {
-                        blindnessTicks = 60;
-                    } else if(player.getCommandSenderWorld().getDifficulty() == Difficulty.HARD) {
-                        blindnessTicks = 80;
+                    switch (player.getCommandSenderWorld().getDifficulty()) {
+                        case EASY:
+                            blindnessTicks = 40;
+                            break;
+                        case NORMAL:
+                            blindnessTicks = 60;
+                            break;
+                        case HARD:
+                            blindnessTicks = 80;
+                            break;
                     }
                     player.addEffect(new MobEffectInstance(MobEffects.BLINDNESS, blindnessTicks, 10, false, false));
                 }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -51,7 +51,7 @@ dependencies {
         exclude(group: "net.fabricmc")
         exclude(group: "net.fabricmc.fabric-api")
     }
-    modImplementation("curse.maven:341284-trinkets:${rootProject.trinkets_version}") {
+    modImplementation("curse.maven:trinkets-341284:${rootProject.trinkets_version}") {
         transitive = false
     }
     modRuntimeOnly("com.terraformersmc:modmenu:3.1.0") {


### PR DESCRIPTION
This PR aims to make minor optimisations and code cleanup. I've deliberately left this in a Java 8 style to aid backporting.

- Reduced unnecessary checks
- Replaced if chains with switch where appropriate
- Merged identical switch cases
- Reordered if conditions to do the faster checks first
- Moved some calculations inside the following if statement where appropriate
    - For example, `this.attacker.distanceToSqr()` calculation inside the if statement in EfficientMoveTowardsTargetGoal (before it was always calculated but frequently unused)
- Reuse String arrays