### PR TITLE
Fix null target bug

### DIFF
--- a/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/ai/EfficientMoveTowardsTargetGoal.java
+++ b/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/ai/EfficientMoveTowardsTargetGoal.java
@@ -86,6 +86,7 @@ public class EfficientMoveTowardsTargetGoal extends Goal {
     @Override
     public void tick() {
         LivingEntity livingentity = this.attacker.getTarget();
+        if (livingentity == null) return;
         this.attacker.getLookControl().setLookAt(livingentity, 30.0F, 30.0F);
         double d0 = this.attacker.distanceToSqr(livingentity.getX(), livingentity.getY(), livingentity.getZ());
         --this.delayCounter;


### PR DESCRIPTION
## Fixes: Target Entity Being Null

The target entity can be null, hence why the check exists within `canContinueToUse()`
Handle the target being null within `tick()`

## Applicable Issues

Fixes #337

