### PR TITLE
Add null check to setCustomName in EntityReindeer

### DIFF
--- a/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityReindeer.java
+++ b/common/src/main/java/dev/itsmeow/betteranimalsplus/common/entity/EntityReindeer.java
@@ -701,9 +701,11 @@ public class EntityReindeer extends Animal implements PlayerRideableJumping, IVa
 
     @Override
     public void setCustomName(Component comp) {
-        if(comp.getString().equalsIgnoreCase("rudolph")) {
-            if(this.getVariant().isPresent() && !this.getVariantNameOrEmpty().endsWith("_christmas")) {
-                this.setType(this.getVariantNameOrEmpty() + "_christmas");
+        if (comp != null) {
+            if (comp.getString().equalsIgnoreCase("rudolph")) {
+                if (this.getVariant().isPresent() && !this.getVariantNameOrEmpty().endsWith("_christmas")) {
+                    this.setType(this.getVariantNameOrEmpty() + "_christmas");
+                }
             }
         }
         super.setCustomName(comp);


### PR DESCRIPTION
Fixed bug where setting custom name to null on an EntityReindeer crashes the game. 

From what I can tell setCustomName accepts null and so I've added a null check. Found this when rendering entities in a custom GUI and setting the custom name to null temporarily to prevent it from rendering.

